### PR TITLE
Added firewall feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Requirements
 
 * [concat module](https://github.com/ripienaar/puppet-concat)
+* [firewall module](https://forge.puppetlabs.com/puppetlabs/firewall) (Only required to get the firewall feature working.)
 
 ## Tested on...
 

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -1,0 +1,17 @@
+# = Class nfs::firewall
+#
+class nfs::firewall {
+  $firewall_exists = inline_template("<%= File.exists?('/var/lib/puppet/lib/puppet/provider/firewall/iptables.rb') %>")
+  if $::nfs::server and $::nfs::service_ensure==running and $firewall_exists {
+    firewall { "049 allow incoming nfs tcp-connections":
+      proto   => tcp,
+      dport   => $::nfs::firewall_port,
+      action  => accept,
+    }
+    firewall { "049 allow incoming nfs udp-connections":
+      proto   => udp,
+      dport   => $::nfs::firewall_port,
+      action  => accept,
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,10 +23,12 @@ class nfs (
   include nfs::install
   include nfs::config
   include nfs::service
+  include nfs::firewall
 
   Class['nfs::install'] ->
   Class['nfs::config'] ->
-  Class['nfs::service']
+  Class['nfs::service'] ->
+  Class['nfs::firewall']
 
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class nfs::params {
       $config_file_mode   = '0644'
       $config_group       = 'root'
       $config_user        = 'root'
+      $firewall_port      = '2049'
       $pkg_ensure         = present
       $pkg_list_client    = 'nfs-utils'
       $pkg_list_server    = 'rpcbind'
@@ -29,6 +30,7 @@ class nfs::params {
       $config_file_mode   = '0644'
       $config_group       = 'root'
       $config_user        = 'root'
+      $firewall_port   	  = '2049'
       $pkg_ensure         = present
       $pkg_list_client    = 'nfs-common'
       $pkg_list_server    = 'nfs-kernel-server'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,4 +1,4 @@
-# = Class nfs
+# = Class nfs::service
 #
 class nfs::service {
   if $::nfs::server {


### PR DESCRIPTION
Hello Tom,

Thanks for your puppet-module. Since we use in our organization a firewall-module, I've added a firewall-file, which opens the port of the NFS-service if its running.
I've also added a file.exists-check to make sure that the firewall-module is used or else just to ignore the firewall-rules.

I'm planning to request a pull for the puppetlabs-firewall-module to add a boolean firewall.exist-facter which says whether a firewall exists or not. So the file.exists-check can be replaced by a check which is delivered by the firewall-module.

Hopefully these changes can be pulled in your repository.

Greatings,

Abdelouahed Haitoute