### PR TITLE
fix exports template

### DIFF
--- a/templates/export.erb
+++ b/templates/export.erb
@@ -1,3 +1,3 @@
-# <%= @name -%>
+# <%= @name %>
 <%= @export_directory -%> <%= @export_target -%>(<%= @export_options -%>)
 


### PR DESCRIPTION
I need this patch to get /etc/exports written in correct format, see the example:

before:

```
# Managed by Puppet

# /srv/nfs01 10.0.1.1/24/srv/nfs01 10.0.1.1/24(rw,sync,no_root_squash)

# /srv/nfs01 10.0.2.1/24/srv/nfs01 10.0.2.1/24(rw,sync,no_root_squash)
```

after:

```
# Managed by Puppet

# /srv/nfs01 10.0.1.1/24
/srv/nfs01 10.0.1.1/24(rw,sync,no_root_squash)

# /srv/nfs01 10.0.2.1/24
/srv/nfs01 10.0.2.1/24(rw,sync,no_root_squash)
```
